### PR TITLE
Update metadata.json. Adding requirement to let this module work with Puppet 6 or greater

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,8 @@
   "project_page": "https://github.com/justinjl6/puppet-hosts",
   "issues_url": "https://github.com/justinjl6/puppet-hosts",
   "dependencies": [
-    {"name":"puppetlabs/stdlib","version_requirement":">= 1.0.0"}
+    {"name":"puppetlabs/stdlib","version_requirement":">= 1.0.0"},
+    {"name":"puppetlabs-host_core","version_requirement":">=1.2.0"}
   ],
   "operatingsystem_support": [
     { "operatingsystem": "CentOS",      "operatingsystemrelease": [ "5", "6", "7" ] },


### PR DESCRIPTION
Since [Puppet 6 took the host resource out of the builtin set of resources](https://www.puppet.com/docs/puppet/7/type#puppet-60-type-changes), we need to import an extra module to make this module work with Puppet 6 or greater.

This new module is owned by puppetlabs and its called [host_core](https://forge.puppet.com/modules/puppetlabs/host_core/readme)